### PR TITLE
Add second PURL title property URI

### DIFF
--- a/classes/parsers/RDFIO_URIToWikiTitleConverter.php
+++ b/classes/parsers/RDFIO_URIToWikiTitleConverter.php
@@ -170,9 +170,10 @@ class RDFIOURIToTitleConverter {
 		$rdfiogPropertiesToUseAsWikiTitle = array(
 			'http://semantic-mediawiki.org/swivt/1.0#page', // Suggestion for new property
 			'http://www.w3.org/2000/01/rdf-schema#label',
-		    'http://purl.org/dc/elements/1.1/title',
-		    'http://www.w3.org/2004/02/skos/core#preferredLabel',
-		    'http://xmlns.com/foaf/0.1/name'
+			'http://purl.org/dc/terms/title',
+			'http://purl.org/dc/elements/1.1/title',
+			'http://www.w3.org/2004/02/skos/core#preferredLabel',
+			'http://xmlns.com/foaf/0.1/name'
 		);
 	}
 


### PR DESCRIPTION
This change adds the property URI `http://purl.org/dc/terms/title`, which has showed up in some datasets, in addition to the other PURL title URI `http://purl.org/dc/elements/1.1/title`.