### PR TITLE
Remove assumption on hard-coded arc2 location in SMW libs folder

### DIFF
--- a/RDFIO.php
+++ b/RDFIO.php
@@ -36,7 +36,7 @@ $wgExtensionMessagesFiles['RDFIOAliases'] = $dir . 'RDFIO.alias.php';
 /* Customize these details if you   *
  * want to use an external database */
 $smwgARC2StoreConfig = array(
-		'db_host' => $wgDBserver,
+        'db_host' => $wgDBserver,
         'db_name' => $wgDBname,
         'db_user' => $wgDBuser,
         'db_pwd' =>  $wgDBpassword,

--- a/RDFIO.php
+++ b/RDFIO.php
@@ -29,18 +29,6 @@ $dir = dirname( __FILE__ ) . '/';
 $wgExtensionMessagesFiles['RDFIO'] = $dir . 'RDFIO.i18n.php';
 $wgExtensionMessagesFiles['RDFIOAliases'] = $dir . 'RDFIO.alias.php';
 
-/****************************
- * ARC2 RDF library for PHP *
- ****************************/
-
-$smwgARC2Path = $smwgIP . '/libs/arc/';
-$smwgARC2MainFile = $smwgARC2Path . '/ARC2.php';
-if ( ! file_exists( $smwgARC2MainFile )) {
-    throw new MWException("ARC2 library is not installed in Semantic Mediawiki libs folder! Please refer to the installation instructions, to fix that: http://www.mediawiki.org/wiki/Extension:RDFIO#Installation");
-} else {
-    require_once( $smwgARC2MainFile );
-}
-
 /**************************
  *  ARC2 RDF Store config *
  **************************/


### PR DESCRIPTION
Figured out that this seems to be the only thing I need to change in order to get the current rdfio/RDFIO master branch to work with MW  1.26.4 and SMW 2.3.1 (as installed via composer).

ARC2 is now installed in `/vendor/semsol/arc2/`, and my install works excellent without the lines removed in this PR.

After these changes, the RDF Import form and default SPARQL query work fine, at least.

Of course, disregard this if you're already fixing it in #21 , and is able to merge it soon (like before SMWCon :) )! If not, I guess this change could be a good first step ... then at least the vagrant box is working.